### PR TITLE
Arrowkeys fix

### DIFF
--- a/client/src/components/Annotate.jsx
+++ b/client/src/components/Annotate.jsx
@@ -147,8 +147,8 @@ class Annotate extends Component {
     if (e.target !== document.body) {
       return;
     }
+    e.preventDefault();
     if (e.code === "Space") {
-      e.preventDefault();
       this.playPause();
     }
     if (e.code === "ArrowRight") {


### PR DESCRIPTION
In Annotate.jsx: in handleKeyDown function moved e.preventDefault() outside if statement so arrowkeys won't scoll the page.