### PR TITLE
added .env to .ebignore

### DIFF
--- a/.ebignore
+++ b/.ebignore
@@ -8,6 +8,4 @@ npm-debug.log
 # AWS EC2 instances
 # the .env on the EC2 instances should always contain the production
 # version of the DB_HOST url
-
-# jk this is commented out for now until because it introduced a new bug
-# .env
+.env


### PR DESCRIPTION
Application can now be deployed using `eb deploy` without having to change .env file beforehand. Only prior step now required is running `npm run build` in the client/ directory.