### PR TITLE
Train Model Concept/Video Filter

### DIFF
--- a/client/src/components/Model/TrainModel.jsx
+++ b/client/src/components/Model/TrainModel.jsx
@@ -216,7 +216,7 @@ class TrainModel extends Component {
     }
     axios.get(`/api/users`, config).then(res => {
       this.setState({
-        users: res.data
+        users: res.data,
       });
     })
   }
@@ -233,8 +233,11 @@ class TrainModel extends Component {
        this.state.modelSelected,
       config
     ).then(res => {
+      let videoids = res.data.map(vid => vid.id);
       this.setState({
-        videos: res.data
+        videos: res.data,
+        videosSelected: this.state.videosSelected.filter(
+          id => videoids.includes(id))
       });
     });
   };
@@ -251,8 +254,11 @@ class TrainModel extends Component {
       videosSelected + '/' + modelSelected,
       config
     )
+    let conceptids = response.data.map(concept => concept.id);
     this.setState({
-      concepts: response.data
+      concepts: response.data,
+      conceptsSelected: this.state.conceptsSelected.filter(
+        id => conceptids.includes(id)),
     });
   }
 

--- a/client/src/components/Model/TrainModel.jsx
+++ b/client/src/components/Model/TrainModel.jsx
@@ -605,6 +605,7 @@ class TrainModel extends Component {
       activeStep,
       openedVideo
     } = this.state;
+    
     if (!videos) {
       return <div>Loading...</div>;
     }


### PR DESCRIPTION
In the train model tab, the states, conceptsSelected and videosSelected, contained options that were not available for to the user. We now filter these states when the concept and video lists are fetched from the backend.