### PR TITLE
Fix backslash problem in concept search

### DIFF
--- a/client/src/components/SelectConcepts/Concepts.jsx
+++ b/client/src/components/SelectConcepts/Concepts.jsx
@@ -186,6 +186,7 @@ class Concepts extends React.Component {
 
   searchConcepts = search => {
     const { concepts } = this.state;
+    search = search.replace(/\\/g, '\\\\');
     const conceptsMatchID = concepts.filter(concept => {
       return concept.id.toString() === search;
     })


### PR DESCRIPTION
Replace 1 backslash with 2 because backslash is also the escape char in regex. Two backslashes will end up being 1 in regex, which is probably what the user wants.